### PR TITLE
deploy (Project/Build) settings.py & Email ENV: 2: Typos

### DIFF
--- a/dash_and_do/settings.py
+++ b/dash_and_do/settings.py
@@ -1075,9 +1075,9 @@ DASH_FROM_SERVER = envs.str('MAILERTOGO_FROM_USER', default='server')
 DASH_DOMAIN = envs.str('MAILTOGO_DOMAIN', default='dash-and-do.xyz')
 # Set admin email
 ADMIN_EMAIL = envs.str('ADMIN_EMAIL',
-    default=f'{DASH_FROM}@{DASH_DOMAIN}')
+    default=f'{DASH_FROM}@{DASH_DOMAIN}'
 SERVER_EMAIL = envs.str('SERVER_EMAIL',
-    default=f'{DASH_FROM_SERVER}@{DASH_DOMAIN})
+    default=f'{DASH_FROM_SERVER}@{DASH_DOMAIN}'
 ADMINS = [ADMIN_EMAIL]
 MANAGERS = ADMINS
 
@@ -1115,9 +1115,9 @@ else:  # noqa PLR5501
         DASH_DOMAIN= envs.str('DASH_DOMAIN', default='dash-and-do.xyz')
         DEFAULT_FROM_EMAIL = f'{FROM}@{DASH_DOMAIN}'
         ADMIN_EMAIL = envs.str('ADMIN_EMAIL',
-            default=f'{FROM}@{MAILERTOGO_DOMAIN}')
+            default=f'{FROM}@{DASH_DOMAIN}'
         SERVER_EMAIL = envs.str('SERVER_EMAIL',
-            default=f'{FROM_SERVER}@{DASH_DOMAIN})
+            default=f'{FROM_SERVER}@{DASH_DOMAIN}'
         EMAIL_HOST = envs.str('DASH_HOST')
         EMAIL_PORT = envs.int('DASH_PORT')
         EMAIL_HOST_USER = envs.str('DASH_HOST_USER')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref~=3.7.2
-cloudinary~=1.34.0
+cloudinary~=1.36.0  # Note: clouindary-cli needs 1.36.0
 cloudinary-cli~=1.9.1
 cryptography~=41.0.3
 dj3-cloudinary-storage~=0.0.6
@@ -29,7 +29,7 @@ sentry-sdk~=1.31.0
 PyGitHub~=2.0.1rc0
 Pillow~=10.0.1
 oauthlib~=3.2.2
-python3-openid~=2.2.6
+python3-openid~=3.2.0 # Bumped to @latest
 python3-saml~=1.11.0
 requests~=2.31.0
 requests-oauthlib~=1.3.1


### PR DESCRIPTION
Deploy: settings, email env vars
Apps:
Intent: Updated settings.py
Issue: Build fails: email env vars
   - Bad ENV vars for MAILERTOGO Fixed:
Target: Epic-Kore
Tag: Deploy, Heroku, Dev
Sprint: 13: Ends 23-10-15
Previous: 23-10-14 v00.03.05:048
Changelog:	23-10-14 v00.03.05:049
Bump:	Version 0.03 for Users App
- Deploy
  - MAILERTOGO Settings - Fixing typos
- add:
- modified:
  - settings: - ENVS for email - Coupled session domains to crsf domain and similar pairing.
- linted:
- Edits:
  - configured EMAIL domain settings for app only.
  - current domain is [appname].herokuapp.com ---
Agilelog:
  - EPIC: #5: https://github.com/iPoetDev/dash-and-do-github/milestone/9
  - FEAT:
    - New User Registration: #102
    - Email Verification: #100
  - STORY: - New Registration User Story: #54 - Confirm Registered User Story: #66