### PR TITLE
fix,deploy (Project/Build) settings.py & URLS/Debug Toolbar

### DIFF
--- a/dash_and_do/urls.py
+++ b/dash_and_do/urls.py
@@ -22,6 +22,7 @@ Changelog:
 #  Copyright (c) 2023.
 
 from django.contrib import admin
+from django.conf import settings
 from django.urls import include
 from django.urls import path
 
@@ -45,15 +46,23 @@ from django.urls import path
 # added: SiteMap in Comments as a Planner
 # added: Core index forms to kore.urls
 
+from django.conf import settings
+from django.urls import include, path
+from django.contrib import admin
 
-# breakpoint()
-urlpatterns = [
+urlpatterns = [] # Base variable defintion
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        path("__debug__/", include(debug_toolbar.urls)),
+    ]
+
+urlpatterns += [
     path('admin/', admin.site.urls),
-    # 2023-09-25
-    path("__debug__/", include("debug_toolbar.urls")),
     path('', include('apps.kore.urls', namespace='kore')),
     path('', include('apps.users.urls', namespace='users')),
-    path('accounts/', include('allauth.urls')),  # checked
+    path('accounts/', include('allauth.urls')),
 ]
 # path('profile/', include('profile.urls', namespace='profile')),
 # path('profile/', include('allauth.urls', namespace='profile')),


### PR DESCRIPTION
Deploy: settings, debug_toolbar if DEBUG:True
Apps:
Intent: Updated settings.py
Issue: Build fails: Fxing
  - ModuleNotFoundError: No module named 'debug_toolbar'
  - path("__debug__/", include("debug_toolbar.urls")), Fixed:
Target: Epic-Kore
Tag: Deploy, Heroku, Dev
Sprint: 13: Ends 23-10-15
Previous: 23-10-14 v00.03.05:050
Changelog:	23-10-14 v00.03.05:051
Bump:	Version 0.03 for Users App
- Deploy
  - Fixing DEBUG_TOOLBAR
- add:
- modified:
  - urls.py: root only enabled Debug Toolbar urls when DEBUG
- linted:
- Edits: ---
Agilelog:
  - EPIC: #5: https://github.com/iPoetDev/dash-and-do-github/milestone/9
  - FEAT:
    - New User Registration: #102
    - Email Verification: #100
  - STORY: - New Registration User Story: #54 - Confirm Registered User Story: #66